### PR TITLE
Add noopener to external links

### DIFF
--- a/now/templates/publications.html
+++ b/now/templates/publications.html
@@ -27,216 +27,216 @@
   <h4>2025</h4>
   <hr>Gaiser, F., Müller, C., Phan, P., Mathes, G. and Steinbauer, M.J., 2025. Europe’s lost landscape sculptors: Today’s potential range of the extinct elephant Palaeoloxodon antiquus.
     In <i>Frontiers of Biogeography</i>, 18, p.e135081.
-    <a href="https://doi.org/10.21425/fob.18.135081" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.21425/fob.18.135081" target="_blank" rel="noopener">[DOI]</a>
     <h4>2024</h4>
     <hr>Bekeraitė, S., Juchnevičiūtė, I. and Spiridonov, A., 2024. Bayesian network analysis reveals the assembly drivers and emergent stability of Eurasian Pleistocene large mammal communities.
     In <i>Journal of Mammalian Evolution</i>, 31(4), pp.1-16.
-    <a href="https://doi.org/10.1007/s10914-024-09735-2" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1007/s10914-024-09735-2" target="_blank" rel="noopener">[DOI]</a>
     <hr>Parker, A.K., Pushkina, D. and Liu, L., 2024, November. An assessment of body size and dietary biases in fossil mammal assemblages of the Pleistocene of Eurasia.
     In <i>Annales Zoologici Fennici</i> (Vol. 61, No. 1, pp. 253-280). Finnish Zoological and Botanical Publishing Board.
-    <a href="https://doi.org/10.5735/086.061.0117" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.5735/086.061.0117" target="_blank" rel="noopener">[DOI]</a>
   <hr>Ren, Y., Xu, Z., Li, M., Dai, W. and Wang, J., 2024. How Geomorphology Maps the Dispersal Barriers of Large Herbivorous Mammals in China.
     <i>Journal of Biogeography.</i>, 51(12), pp.2323-2577.
-    <a href="https://doi.org/10.1111/jbi.15007" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1111/jbi.15007" target="_blank" rel="noopener">[DOI]</a>
   <hr>Lubbers, K.E., Samuels, J.X. and Joyner, T.A., 2024. Species distribution modeling of North American beavers from the late Pliocene into the future.
     <i>Journal of Mammalogy</i>, p.gyae131.
-    <a href="https://doi.org/10.1093/jmammal/gyae131" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1093/jmammal/gyae131" target="_blank" rel="noopener">[DOI]</a>
   <hr>Juhn, M.S., Balisi, M.A., Doughty, E.M., Friscia, A.R., Howenstine, A.O., Jacquemetton, C., Marcot, J., Nugen, S. and Van Valkenburgh, B., 2024. Cenozoic climate change and the evolution of North American mammalian predator ecomorphology.
     <i>Paleobiology</i>, pp.1-10.
-    <a href="https://doi.org/10.1017/pab.2024.27" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1017/pab.2024.27" target="_blank" rel="noopener">[DOI]</a>
   <hr>Foister, T.I., Liu, L., Saarinen, J., Tallavaara, M., Zhang, H. and Žliobaitė, I., 2024. Quantifying heterogeneity of hominin environments in and out of Africa using herbivore dental traits.
     <i>Quaternary Science Reviews</i>, 337, p.108791.
-    <a href="https://doi.org/10.1016/j.quascirev.2024.108791" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1016/j.quascirev.2024.108791" target="_blank" rel="noopener">[DOI]</a>
   <hr>Žliobaitė, I., 2024. Laws of macroevolutionary expansion.
     <i>Proceedings of the National Academy of Sciences</i>, 121(33), p.e2314694121.
-    <a href="https://doi.org/10.1073/pnas.2314694121" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1073/pnas.2314694121" target="_blank" rel="noopener">[DOI]</a>
   <hr>Faurby, S., Silvestro, D., Werdelin, L. and Antonelli, A., 2024. Reliable biogeography requires fossils: insights from a new species-level phylogeny of extinct and living carnivores.
     <i>Proceedings of the Royal Society B</i>, 291(2028), p.20240473.
-    <a href="https://doi.org/10.1098/rspb.2024.0473" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1098/rspb.2024.0473" target="_blank" rel="noopener">[DOI]</a>
   <hr>Polly, P. D. (2024). Book review: Evolution of Cenozoic land mammal faunas and ecosystems: 25 years of the NOW database of fossil mammals: by Lars W. van den Hoek OstendeIsaac Casanovas-Vilar, Lars W. van den Hoek Ostende, Christine M. Janis, and Juha Saarinen (eds.), 231 pp.
     <i>Historical Biology</i>, 1–2.
-    <a href="https://doi.org/10.1080/08912963.2024.2357603" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1080/08912963.2024.2357603" target="_blank" rel="noopener">[DOI]</a>
   <h4>2023</h4>
   <hr>Madern, P.A., Braumuller, Y., Mavikurt, A.C., Mayda, S., Bergwerff, L., Janssen, N., Cantalapiedra, J., Robles, J.M., Casanovas-Vilar, I., van Welzen, P.C. and van den Hoek Ostende, L.W., 2024. Where’s dinner? Variation in carnivoran distributional responses to the mid-Vallesian faunal turnover.
     <i>Palaeobiodiversity and Palaeoenvironments</i>, 104(1), pp.181-190.
-    <a href="https://doi.org/10.1007/s12549-023-00588-w" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1007/s12549-023-00588-w" target="_blank" rel="noopener">[DOI]</a>
   <hr>Liu, L., Galbrun, E., Tang, H., Kaakinen, A., Zhang, Z., Zhang, Z. and Žliobaitė, I., 2023. The emergence of modern zoogeographic regions in Asia examined through climate–dental trait association patterns.
     <i>Nature Communications</i>, 14(1), p.8194.
-    <a href="https://doi.org/10.1038/s41467-023-43807-w" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1038/s41467-023-43807-w" target="_blank" rel="noopener">[DOI]</a>
   <hr>Bibi, F. and Cantalapiedra, J.L., 2023. Plio-Pleistocene African megaherbivore losses associated with community biomass restructuring.
     <i>Science, 380(6649)</i>, pp.1076-1080.
-    <a href="https://doi.org/10.1126/science.add8366" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1126/science.add8366" target="_blank" rel="noopener">[DOI]</a>
   <hr>Orak, Z., Kostopoulos, D.S. and Ataabadi, M.M., 2023. Late Miocene large-sized Bovidae (Mammalia) from Dimeh, SW Iran: contribution to depositional diachrony and palaeobiogeography.
     <i>Geobios.</i>
-    <a href="https://doi.org/10.1016/j.geobios.2023.05.001" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1016/j.geobios.2023.05.001" target="_blank" rel="noopener">[DOI]</a>
   <hr>Jiangzuo, Q., Werdelin, L., Sanisidro, O., Yang, R., Fu, J., Li, S., Wang, S. and Deng, T., 2023. Origin of adaptations to open environments and social behaviour in sabretoothed cats from the northeastern border of the Tibetan Plateau.
     <i>Proceedings of the Royal Society B, 290(1997)</i>, p.20230019.
-    <a href="https://doi.org/10.1098/rspb.2023.0019" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1098/rspb.2023.0019" target="_blank" rel="noopener">[DOI]</a>
     <h4>2022</h4>
   <hr>Farias, R.C. and Miron, S., 2022. A generalized approach for Boolean matrix factorization.
     <i>Signal Processing</i>, p.108887.
-    <a href="https://doi.org/10.1016/j.sigpro.2022.108887" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1016/j.sigpro.2022.108887" target="_blank" rel="noopener">[DOI]</a>
   <hr>Oberg, D.E. and Samuels, J.X., 2022. Fossil moles from the Gray Fossil Site (Tennessee): Implications for diversification and evolution of North American Talpidae.
     <i>Palaeontologia Electronica</i>, 25(3), pp.1-39.
-    <a href="https://doi.org/10.26879/1150" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.26879/1150" target="_blank" rel="noopener">[DOI]</a>
   <hr>Lintulaakso, K., Tatti, N. and Žliobaitė, I., 2022. Quantifying mammalian diets.
     <i>Mammalian Biology</i>, pp.1-15.
-    <a href="https://doi.org/10.1007/s42991-022-00323-6" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1007/s42991-022-00323-6" target="_blank" rel="noopener">[DOI]</a>
   <hr>Huang, S., Saarinen, J.J., Eyres, A., Eronen, J.T. and Fritz, S.A., 2022. Mammalian body size evolution was shaped by habitat transitions as an indirect effect of climate change.
     <i>Global Ecology and Biogeography, 00</i>, pp.1-12.
-    <a href="https://doi.org/10.1111/geb.13594" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1111/geb.13594" target="_blank" rel="noopener">[DOI]</a>
   <hr>Bōgner, E. and Samuels, J.X., 2022. The first canid from the Gray Fossil Site in Tennessee: new perspective on the distribution and ecology of Borophagus.
     <i>Journal of Paleontology</i>, pp.1-11.
-    <a href="https://doi.org/10.1017/jpa.2022.46" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1017/jpa.2022.46" target="_blank" rel="noopener">[DOI]</a>
   <hr>Žliobaitė, I., 2022. Recommender systems for fossil community distribution modelling.
     <i>Methods in Ecology and Evolution, 13(8)</i>, pp.1690-1706.
-    <a href="https://doi.org/10.1111/2041-210x.13916" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1111/2041-210x.13916" target="_blank" rel="noopener">[DOI]</a>
   <hr>Toivonen, J., Fortelius, M. and Žliobaitė, I., 2022. Do species factories exist? Detecting exceptional patterns of evolution in the mammalian fossil record.
     <i>Proceedings of the Royal Society B, 289(1972)</i>, p.20212294.
-    <a href="https://doi.org/10.1098/rspb.2021.2294" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1098/rspb.2021.2294" target="_blank" rel="noopener">[DOI]</a>
 
     <h4>2021</h4>
   <hr>Antoine, P.O., Reyes, M.C., Amano, N., Bautista, A.P., Chang, C.H., Claude, J., De Vos, J. and Ingicco, T., 2021. A new rhinoceros clade from the Pleistocene of Asia sheds light on mammal dispersals to the Philippines.
     <i>Zoological Journal of the Linnean Society</i>, zlab009.
-    <a href="https://doi.org/10.1093/zoolinnean/zlab009" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1093/zoolinnean/zlab009" target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Hall, A.S. and Cote, S., 2021. Ruminant mesowear reveals consistently browse-dominated diets throughout the early and middle Miocene of eastern Africa.
     <i>Palaeogeography, Palaeoclimatology, Palaeoecology</i>, p.110253.
-    <a href="https://doi.org/10.1016/j.palaeo.2021.110253" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1016/j.palaeo.2021.110253" target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Iliopoulos, G. and Roussiakis, S., 2022. The fossil record of giraffes (Mammalia: Giraffidae) in Greece.
     In <i>Fossil Vertebrates of Greece Vol. 2</i> (pp. 301-333). Springer, Cham.
-    <a href="https://doi.org/10.1007/978-3-030-68442-6_10" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1007/978-3-030-68442-6_10" target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Pappa, S. and Tsoukala, E., 2022. The Fossil Record of Bears (Mammalia: Carnivora: Ursidae) in Greece.
     In <i>Fossil Vertebrates of Greece Vol. 2</i> (pp. 595-627). Springer, Cham.
-    <a href="https://doi.org/10.1007/978-3-030-68442-6_21" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1007/978-3-030-68442-6_21" target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Radomski, T., 2021. Rapoport effects are inconsistently demonstrated through time.
     <i>Palaeogeography, Palaeoclimatology, Palaeoecology</i>, p.110568.
-    <a href="https://doi.org/10.1016/j.palaeo.2021.110568" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1016/j.palaeo.2021.110568" target="_blank" rel="noopener">[DOI]</a>
   
   <hr>Žliobaitė, I. and Fortelius, M., 2021. On calibrating the completometer for the mammalian fossil record.
     <i>Paleobiology</i>, pp.1-11.
-    <a href="https://doi.org/10.1017/pab.2021.22" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1017/pab.2021.22" target="_blank" rel="noopener">[DOI]</a>
   
   <h4>2020</h4>
   <hr>Bai, B., Meng, J., Janis, C.M., Zhang, Z.Q. and Wang, Y.Q., 2020. Perissodactyl diversities and responses to climate changes as reflected by dental homogeneity during the Cenozoic in Asia.
     <i>Ecology and Evolution, 10(13)</i>, pp.6333-6355.
-    <a href="https://doi.org/10.1002/ece3.6363" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1002/ece3.6363" target="_blank" rel="noopener">[DOI]</a>
 
     <hr>Catena, Angeline M. and Croft, Darin A. 2020. What are the best modern analogs for ancient South American mammal communities? Evidence from ecological diversity analysis (EDA).
     <i>Palaeontologia Electronica</i>, 23(1):a03.
-    <a href="https://doi.org/10.26879/962" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.26879/962" target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Faith, J.T., Braun, D.R., Davies, B., DeSantis, L.R., Douglass, M.J., Esteban, I., Hare, V., Levin, N.E., Luyt, J., Pickering, R. and Power, M.J., 2020. Ecometrics and the paleoecological implications of Pleistocene faunas from the western coastal plains of the Cape Floristic Region, South Africa.
     <i>Journal of Quaternary Science.</i>
-    <a href="https://doi.org/10.1002/jqs.3247" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1002/jqs.3247" target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Koufos, G.D., 2020. New tragulid remains from the early/middle Miocene and a revision of their occurrence in Greece.
     <i>Historical Biology</i>, pp.1-16.
-    <a href="https://doi.org/10.1080/08912963.2020.1795650" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1080/08912963.2020.1795650" target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Lars W. van den Hoek Ostende , Melike Bilgin , Yanell Braumuller , János Hír , Peter Joniak , Pablo Peláez-Campomanes , Jérôme Prieto , Panagiotis Skandalos , Isaac Casanovas-Vilar. (2020). Generically speaking, a survey on Neogene rodent diversity at the genus level in the NOW Database.
     <i>Fossil Imprint</i>, 46. 118-127.
-    <a href="https://doi.org/10.37520/fi.2020.008" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.37520/fi.2020.008" target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Schap, J.A., Samuels, J.X. and Joyner, A., 2020. Ecometric estimation of present and past climate of North America using crown heights of rodents and lagomorphs.
     <i>Palaeogeography, Palaeoclimatology, Palaeoecology</i>, p.110144.
-    <a href="https://doi.org/10.1016/j.palaeo.2020.110144" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1016/j.palaeo.2020.110144" target="_blank" rel="noopener">[DOI]</a>
 
   <h4>2019</h4>
   <hr>Faurby, S., Werdelin, L. and Antonelli, A., 2019. Dispersal ability predicts evolutionary success among mammalian carnivores.
     <i>bioRxiv</i>, p.755207.
-    <a href="https://doi.org/10.1101/755207" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1101/755207" target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Figueirido, B., Palmqvist, P., Pérez-Claros, J.A. and Janis, C.M., 2019. Sixty-six million years along the road of mammalian ecomorphological specialization.
     <i>Proceedings of the National Academy of Sciences</i>, 116(26), pp.12698-12703.
-    <a href="https://doi.org/10.1073/pnas.1821825116" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1073/pnas.1821825116" target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Ge, D., Feijó, A., Cheng, J., Lu, L., Liu, R., Abramov, A.V., Xia, L., Wen, Z., Zhang, W., Shi, L. and Yang, Q., 2019. Evolutionary history of field mice (Murinae: Apodemus), with emphasis on morphological variation among species in China and description of a new species.
     <i>Zoological Journal of the Linnean Society</i>, 187(2), pp.518-534.
-    <a href="https://doi.org/10.1093/zoolinnean/zlz032" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1093/zoolinnean/zlz032" target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Oksanen, O., Žliobaitė, I., Saarinen, J., Lawing, A.M. and Fortelius, M., 2019. A Humboldtian approach to life and climate of the geological past: estimating palaeotemperature from dental traits of mammalian communities.
     <i>Journal of Biogeography</i>, 46(8), pp.1760-1776.
-    <a href="https://doi.org/10.1111/jbi.13586" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1111/jbi.13586" target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Wessels, W., de Bruijn, H., Marković, Z. and Milivojević, M., 2019. Small mammals from the opencast lignite mine Gračanica (Bugojno, middle Miocene), Bosnia and Herzegovina.
     <i>Palaeobiodiversity and Palaeoenvironments</i>, pp.1-6.
-    <a href="https://doi.org/10.1007/s12549-018-0366-8" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1007/s12549-018-0366-8" target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Žliobaitė, I., 2019. Revisiting biogeography of livestock animal domestication.
     <i>bioRxiv</i>, p.786442.
-    <a href="https://doi.org/10.1101/786442" target="_blank">[DOI]</a>
+    <a href="https://doi.org/10.1101/786442" target="_blank" rel="noopener">[DOI]</a>
 
   <h4>2018</h4>
 
   <hr>Kaya, F., Bibi, F., Zliobaite, I., Eronen, J., Hui, T. and Fortelius, M. 2018.
   The rise and fall of the Old World savannah fauna and the origins of the African savannah biome.
   <i>Nature Ecology & Evolution</i> 2, 241-246.
-  <a href="https://doi.org/10.1038/s41559-017-0414-1" target="_blank">[DOI]</a>
+  <a href="https://doi.org/10.1038/s41559-017-0414-1" target="_blank" rel="noopener">[DOI]</a>
 
   <h4>2017</h4>
 
   <hr>Zliobaite, I., Puolamäki, K., Eronen, J. and Fortelius, M. 2017. A survey of computational methods for fossil data analysis.
       <i>Evolutionary Ecology Research</i> 18.
-      <a href="http://evolutionary-ecology.com/issues/forthcoming/ar3066.pdf" target="_blank">[PDF]</a>
+      <a href="http://evolutionary-ecology.com/issues/forthcoming/ar3066.pdf" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Sukselainen, L. K., Kaakinen, A., Eronen, J. T., Passey, B. H., Harrison, T., Zhaoqun, Z. and Fortelius, M. 2017. The palaeoenvironment of the middle Miocene pliopithecid locality in Damiao, Inner Mongolia, China.
-      <i>Journal of Human Evolution</i> 108: 31-46. <a href="https://doi.org/10.1016/j.jhevol.2017.03.014" target="_blank">[DOI]</a>
+      <i>Journal of Human Evolution</i> 108: 31-46. <a href="https://doi.org/10.1016/j.jhevol.2017.03.014" target="_blank" rel="noopener">[DOI]</a>
 
   <h4>2016</h4>
 
   <hr>Fortelius, H. L. M., Zliobaite, I., Kaya, F., Bibi, F., Bobe, R., Leakey, L., Leakey, M., Patterson, D., Rannikko, J. C. and Werdelin, L. 2016. An ecometric analysis of the fossil mammal record of the Turkana Basin.
       <i>Philosophical Transactions of the Royal Society. Biological Sciences</i> 371(1698).
-      <a href="http://dx.doi.org/10.1098/rstb.2015.0232 " target="_blank">[DOI]</a>
+      <a href="http://dx.doi.org/10.1098/rstb.2015.0232 " target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Mirzaie Ataabadi, M., Kaakinen, A. P., Kunimatsu, Y., Nakaya, H., Orak, Z., Paknia, M., Sakai, T., Salminen, M. J., Sawada, Y., Sen, S., Suwa, G., Watabe, M., Zaree, G., Zhaoqun, Z. and Fortelius, H. L. M. 2016. The late Miocene hominoid-bearing site in the Maragheh Formation, Northwest Iran.
       <i>Palaeobiodiversity and Palaeoenvironments</i> 96(3): 349-371.
-      <a href="http://dx.doi.org/10.1007/s12549-016-0241-4" target="_blank">[DOI]</a>
+      <a href="http://dx.doi.org/10.1007/s12549-016-0241-4" target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Salonen, J. S., Saarinen, J. J., Miettinen, A. I., Hirvas, H., Usoltseva, M., Fortelius, H. L. M. and Sorsa, M. 2016. The northernmost discovery of a Miocene proboscidean bone in Europe.
       <i>Palaeogeography, Palaeoclimatology, Palaeoecology</i> 454: 202-211.
-      <a href="http://dx.doi.org/10.1016/j.palaeo.2016.04.034 " target="_blank">[DOI]</a>
+      <a href="http://dx.doi.org/10.1016/j.palaeo.2016.04.034 " target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Kaya, F., Kaymakci, N., Bibi, F., Eronen, J. T., Pehlevan, C., Erkman, A., Langereis, C. and Fortelius, M. 2016. Magnetostratigraphy and paleoecology of the hominid-bearing locality Çorakyerler, Tuglu Formation (Çankiri Basin, Central Anatolia).
       <i>Journal of Vertebrate Paleontology</i> 36(2).
-      <a href="http://dx.doi.org/10.1080/02724634.2015.1071710 " target="_blank">[DOI]</a>
+      <a href="http://dx.doi.org/10.1080/02724634.2015.1071710 " target="_blank" rel="noopener">[DOI]</a>
 
   <h4>2015</h4>
 
   <hr>Fortelius, H. L. M., Geritz, S. A. H., Gyllenberg, M. A. G., Raia, P. and Toivonen, J. T. 2015. Modeling the Population-Level Processes of Biodiversity Gain and Loss at Geological Timescales.
       <i>American Naturalist</i> 186(6): 742-754.
-      <a href="http://dx.doi.org/10.1086/683660 " target="_blank">[DOI]</a>
+      <a href="http://dx.doi.org/10.1086/683660 " target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Arppe, L., Kaakinen, A., Passey, B., Zhang, Z. and Fortelius, M. 2015.
       <i> Small mammal tooth enamel carbon isotope record of C4 grasses in late Neogene China.</i> 133: 288-297.
-      <a href="https://doi.org/10.1016/j.gloplacha.2015.09.003 " target="_blank">[DOI]</a>
+      <a href="https://doi.org/10.1016/j.gloplacha.2015.09.003 " target="_blank" rel="noopener">[DOI]</a>
 
   <hr>Sukselainen, L., Fortelius, M. & Harrison, T. 2015. Co-occurrence of pliopithecoid and hominoid primates in the fossil record: An ecometric analysis.
       <i>Journal of Human Evolution.</i> 84: 25-41.
-      <a href="https://doi.org/10.1016/j.jhevol.2015.04.009 " target="_blank">[DOI]</a>
+      <a href="https://doi.org/10.1016/j.jhevol.2015.04.009 " target="_blank" rel="noopener">[DOI]</a>
 
   <h4>2014</h4>
 
   <hr>Fortelius, M., Eronen, J.T., Kaya, F., Tang, H., Raia, P., Puolamäki, K. 2014. Evolution of Neogene mammals in Eurasia: environmental forcing and biotic interactions. <i>Annual Reviews of Earth and Planetary Science</i> 42: 579–604, doi: 10.1146/annurev-earth-050212-124030.
 
-  <hr>Eronen, J.T., Kaakinen, A., Liu, L., Passey, B.H., Tang, H., Zhang, Z. 2014. Here be Dragons: Mesowear of the classic Chinese "Hipparion" faunas from Baode, Shanxi Province, China. <i>Annales Zoologici Fennici</i> 51: 227-244. <a href="{% static "now/pdf/Eronen_etal_2014_Dragons.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Eronen, J.T., Kaakinen, A., Liu, L., Passey, B.H., Tang, H., Zhang, Z. 2014. Here be Dragons: Mesowear of the classic Chinese "Hipparion" faunas from Baode, Shanxi Province, China. <i>Annales Zoologici Fennici</i> 51: 227-244. <a href="{% static "now/pdf/Eronen_etal_2014_Dragons.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Bingham, E. and Mannila, H. 2014. Towards Computational Techniques for Identifying Candidate Chronofaunas. <i>Annales Zoologici Fennici</i> 51: 43-48.
 
-  <hr>Saarinen, J.J., Boyer, A.G., Brown, J.H, Costa, D.P., Ernest, S.K.M., Evans, A.R., Fortelius, M., Gittleman, J.L., Hamilton, M.J., Harding, L.E., Lintulaakso, K., Lyons, S.K., Okie, J.G., Sibly, R.M., Stephens, P.R., Theodor, J., Uhen, M.D., Smith, F.A. 2014. Patterns of maximum body size evolution in Cenozoic land mammals: eco-evolutionary processes and abiotic forcing. <i>Proceedings of the Royal Society B</i> 281, doi: 10.1098/rspb.2013.2049. <a href="{% static "now/pdf/Saarinen_etal_2014_ProcB.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Saarinen, J.J., Boyer, A.G., Brown, J.H, Costa, D.P., Ernest, S.K.M., Evans, A.R., Fortelius, M., Gittleman, J.L., Hamilton, M.J., Harding, L.E., Lintulaakso, K., Lyons, S.K., Okie, J.G., Sibly, R.M., Stephens, P.R., Theodor, J., Uhen, M.D., Smith, F.A. 2014. Patterns of maximum body size evolution in Cenozoic land mammals: eco-evolutionary processes and abiotic forcing. <i>Proceedings of the Royal Society B</i> 281, doi: 10.1098/rspb.2013.2049. <a href="{% static "now/pdf/Saarinen_etal_2014_ProcB.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Liow, L.H. and Finarelli, J.A. 2014. A dynamic global equilibrium in carnivoran diversification over 20 million years. <i>Proceedings of the Royal Society B</i> 281: 20132312. http://dx.doi.org/10.1098/rspb.2013.2312
 
-  <hr>Martin-Serra, A., Figueirido, B., Palmqvist, P. 2014. A Three-Dimensional Analysis of Morphological Evolution and Locomotor Performance of the Carnivoran Forelimb. <i>PLoS ONE</i> 9(1): e85574. <a href="{% static "now/pdf/Martin-Serra_etal2014_PloSONE.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Martin-Serra, A., Figueirido, B., Palmqvist, P. 2014. A Three-Dimensional Analysis of Morphological Evolution and Locomotor Performance of the Carnivoran Forelimb. <i>PLoS ONE</i> 9(1): e85574. <a href="{% static "now/pdf/Martin-Serra_etal2014_PloSONE.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Wu, S., Zhang, F., Edwards, S. V., Wu, W., Ye, J., Bi, S., Ni, X., Quan, C., Meng, J., Organ, C. L. 2014. The evolution of bipedalism in jerboas (Rodentioa: Dipopoidea): Origin in humid and forested environments. <i>Evolution</i> 68(7): 2108-2118.
 
   <h4>2013</h4>
 
-  <hr>Raia, P. and Fortelius, M. 2013. Cope’s Law of the Unspecialized, Cope’s Rule, and weak directionality in evolution. <i>Evolutionary Ecology Research</i> 15: 747–756. <a href="{% static "now/pdf/Raia_Fortelius_2013_EvoEcoR.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Raia, P. and Fortelius, M. 2013. Cope’s Law of the Unspecialized, Cope’s Rule, and weak directionality in evolution. <i>Evolutionary Ecology Research</i> 15: 747–756. <a href="{% static "now/pdf/Raia_Fortelius_2013_EvoEcoR.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Mirzaie Ataabadi, M., Liu, L., Eronen, J. T., Bernor, R., Fortelius, M. 2013. Continental Scale Patterns in Neogene Mammal Community Evolution and Biogeography: A Europe-Asia Perspective. Pp. 629-655 in Wang, X., Flynn, L.J. and Fortelius, M. (Eds), <i>Fossil Mammals of Asia</i>. New York: Columbia University Press.
 
@@ -244,9 +244,9 @@
 
   <hr>Zhang, Z., Kaakinen, A. P., Liu, L., Lunkka, J.P., Sen, S., Gose, W.A., Qiu, Z. Zheng, S., Fortelius, M. 2013. Mammalian biochronology of the Late Miocene Bahe Formation. Pp. 187-202 in Wang, X., Flynn, L.J. and Fortelius, M. (Eds), <i>Fossil Mammals of Asia</i>. New York, Columbia University Press.
 
-  <hr>Okie, J.G., Boyer, A.G., Brown, J.H., Costa, D.P., Ernest, S.K.M., Evans, A.R., Fortelius, M., Gittleman, J.L., Hamilton, M.J., Harding, L.E., Lintulaakso, K., Lyons, S.K., Saarinen, J.J., Smith, F.A., Stephens, P.R., Theodor, J., Uhen, M.D., Sibly, R.M. 2013. Effects of allometry, productivity and lifestyle on rates and limits of body size evolution. <i>Proceedings of the Royal Society B</i> 280: 20131007 (online June 13). <a href="{% static "now/pdf/Okie_etal2013_ProcB.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Okie, J.G., Boyer, A.G., Brown, J.H., Costa, D.P., Ernest, S.K.M., Evans, A.R., Fortelius, M., Gittleman, J.L., Hamilton, M.J., Harding, L.E., Lintulaakso, K., Lyons, S.K., Saarinen, J.J., Smith, F.A., Stephens, P.R., Theodor, J., Uhen, M.D., Sibly, R.M. 2013. Effects of allometry, productivity and lifestyle on rates and limits of body size evolution. <i>Proceedings of the Royal Society B</i> 280: 20131007 (online June 13). <a href="{% static "now/pdf/Okie_etal2013_ProcB.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
-  <hr>Uhen, M. D., Barnosky, A. D., Bills, B., Blois, J., Carrano, M. T., Carrasco, M. A., Erickson, G. M., Eronen, J. T., Fortelius, M., Graham, R. W., Grimm, E. C., O'Leary, M. A., Mast, A., Piel, W. H., Polly, P. D., Säilä, L. K. 2013. From card catalogs to computers: Databases in vertebrate paleontology. <i>Journal of Vertebrate Paleontology</i> 33:13-28. <a href="{% static "now/pdf/Uhen_etal_2013_JVP.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Uhen, M. D., Barnosky, A. D., Bills, B., Blois, J., Carrano, M. T., Carrasco, M. A., Erickson, G. M., Eronen, J. T., Fortelius, M., Graham, R. W., Grimm, E. C., O'Leary, M. A., Mast, A., Piel, W. H., Polly, P. D., Säilä, L. K. 2013. From card catalogs to computers: Databases in vertebrate paleontology. <i>Journal of Vertebrate Paleontology</i> 33:13-28. <a href="{% static "now/pdf/Uhen_etal_2013_JVP.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Tang, H., Eronen, J.T., Micheels, A., Ahrens, B. 2013. Strong interannual variation of the Asian summer monsoon in the Late Miocene. <i>Climate Dynamics</i> 41: 135-153
 
@@ -254,46 +254,46 @@
 
   <h4>2012</h4>
 
-  <hr>Evans, A.R., Jones, D., Boyer, A.G., Brown, J.H., Costa, D.P., Dayan, T., Ernest, S.K.M., Fitzgerald, E.M.G. Fortelius, M. Gittleman, J.L. Hamilton, M.J., Harding, L.E., Lintulaakso, K., Lyons, S.K., Okie, J.G., Saarinen, J.J., Sibly, R.M., Smith, F.A., Stephens, P.R., Theodor, J., Uhen, M.D. 2012. Maximum rates of body size macroevolution in mammals. <i>PNAS</i> 109: 4187-4190. <a href="{% static "now/pdf/Evans_etal_2012_PNAS.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Evans, A.R., Jones, D., Boyer, A.G., Brown, J.H., Costa, D.P., Dayan, T., Ernest, S.K.M., Fitzgerald, E.M.G. Fortelius, M. Gittleman, J.L. Hamilton, M.J., Harding, L.E., Lintulaakso, K., Lyons, S.K., Okie, J.G., Saarinen, J.J., Sibly, R.M., Smith, F.A., Stephens, P.R., Theodor, J., Uhen, M.D. 2012. Maximum rates of body size macroevolution in mammals. <i>PNAS</i> 109: 4187-4190. <a href="{% static "now/pdf/Evans_etal_2012_PNAS.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Bradshaw, C.D., Lunt, D.J., Flecker, R., Salzmann, U., Pound, M.J., Haywood, A.M., Eronen, J.T. 2012. The relative roles of CO2 and palaeogeography in determining late Miocene climate: results from a terrestrial model-data comparison. <i> Climate of the Past</i> 8: 1257-1285, doi:10.5194/cp-8-1257-2012
 
   <hr>Eronen, J.T., Fortelius, M., Micheels, A., Portmann, F.T., Puolamäki, K., Janis, C.M. 2012. Neogene Aridification of the Northern Hemisphere. <i>Geology</i> 40: 823-826. http://dx.doi.org/10.1130/G33147.1
 
-  <hr>Eronen, J.T., Micheels, A., Utescher, T. 2012. Comparison of estimates for Mean Annual Precipitation from different proxies. A Pilot Study for European Neogene. <i>Evolutionary Ecology Research</i> 13: 851-867. <a href="{% static "now/pdf/Eronen_etal_2012_EvoEcoR.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Eronen, J.T., Micheels, A., Utescher, T. 2012. Comparison of estimates for Mean Annual Precipitation from different proxies. A Pilot Study for European Neogene. <i>Evolutionary Ecology Research</i> 13: 851-867. <a href="{% static "now/pdf/Eronen_etal_2012_EvoEcoR.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Liu, L., Puolamäki, K., Eronen, J.T., Mirzaie, M., Hernesniemi, E., Fortelius, M. 2012. Estimating Net Primary Productivity from Dental Traits. <i>Proceedings of the Royal Society B</i> 27: 2793-2799, http://dx.doi.org/10.1098/rspb.2012.0211
 
-  <hr>Raia P., Carotenuto F., Passaro F., Fulgione D., Fortelius, M. 2012. Ecological specialization in fossil mammals explains Cope's rule. <i>American Naturalist</i> 179: 328-337. <a href="{% static "now/pdf/Raia_etal_AmNat2012.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Raia P., Carotenuto F., Passaro F., Fulgione D., Fortelius, M. 2012. Ecological specialization in fossil mammals explains Cope's rule. <i>American Naturalist</i> 179: 328-337. <a href="{% static "now/pdf/Raia_etal_AmNat2012.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Raia P., Passaro F., Carotenuto F. 2012. Habitat tracking, stasis and survival in Neogene large mammals. <i>Biology Letters</i> 8: 64-66.
 
 
   <h4>2011</h4>
 
-  <hr>Deng, T., X. Wang, M. Fortelius, Q. Li, Y. Wang, Z.J. Tseng, G.T. Takeuchi, J. E. Saylor, L.K. Säilä, G. Xie. 2011. Out of Tibet: Pliocene woolly rhino suggests high-plateau origin of Ice Age megaherbivores. <i>Science</i> 333: 1285-1288. <a href="{% static "now/pdf/Deng_etal_2011_Science.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Deng, T., X. Wang, M. Fortelius, Q. Li, Y. Wang, Z.J. Tseng, G.T. Takeuchi, J. E. Saylor, L.K. Säilä, G. Xie. 2011. Out of Tibet: Pliocene woolly rhino suggests high-plateau origin of Ice Age megaherbivores. <i>Science</i> 333: 1285-1288. <a href="{% static "now/pdf/Deng_etal_2011_Science.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Eronen, J. T., Evans, A. R., Fortelius, M., Jernvall, J. 2011. Genera are often better than species for detecting evolutionary change in the fossil record: A reply to Salesa et al. <i>Evolution</i> 65: 1514-1516.
 
-  <hr>Raia, P., Carotenuto, F., Eronen, J.T., Fortelius, M. 2011. Longer in the tooth, shorter in the record? The evolutionary correlates of hypsodonty in Neogene ruminants. <i>Proceedings of the Royal Society B.</i> 278, 3474-3481. <a href="{% static "now/pdf/Raia_etal_2011.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Raia, P., Carotenuto, F., Eronen, J.T., Fortelius, M. 2011. Longer in the tooth, shorter in the record? The evolutionary correlates of hypsodonty in Neogene ruminants. <i>Proceedings of the Royal Society B.</i> 278, 3474-3481. <a href="{% static "now/pdf/Raia_etal_2011.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
-  <hr>Tang, H., Micheels, A., Eronen, J.T., Fortelius, M. 2011. A regional climate model experiment to investigate the Asian monsoon in the Late Miocene. <i>Climate of the Past</i> 7: 847-868. <a href="http://www.clim-past.net/7/847/2011/cp-7-847-2011.html" target="_blank">[PDF]</a>
+  <hr>Tang, H., Micheels, A., Eronen, J.T., Fortelius, M. 2011. A regional climate model experiment to investigate the Asian monsoon in the Late Miocene. <i>Climate of the Past</i> 7: 847-868. <a href="http://www.clim-past.net/7/847/2011/cp-7-847-2011.html" target="_blank" rel="noopener">[PDF]</a>
 
-  <hr>Micheels, A., Bruch, A.A., Eronen, J.T. , Fortelius, M., Harzhauser, M., Utescher, T. Mosbrugger, V. 2011. Analysis of heat transport mechanisms from a Late Miocene model experiment with a fully-coupled atmosphere-ocean general circulation model. <i>Palaeoclimatology, Palaeogeography, Palaeoecology</i> 304: 337-350. <a href="{% static "now/pdf/Micheels_etal_2011.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Micheels, A., Bruch, A.A., Eronen, J.T. , Fortelius, M., Harzhauser, M., Utescher, T. Mosbrugger, V. 2011. Analysis of heat transport mechanisms from a Late Miocene model experiment with a fully-coupled atmosphere-ocean general circulation model. <i>Palaeoclimatology, Palaeogeography, Palaeoecology</i> 304: 337-350. <a href="{% static "now/pdf/Micheels_etal_2011.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
-  <hr>Polly, P.D., Eronen, J.T., Fred, M., Dietl, G., Mosbrugger, V., Scheidegger, C., Frank, D., Damuth, J., Stenseth, N.-C., Fortelius, M. 2011. History Matters: Integrative Climate Change Biology. <i>Proceedings of the Royal Society B</i> 278: 1131-1140. <a href="{% static "now/pdf/Polly_etal_2011.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Polly, P.D., Eronen, J.T., Fred, M., Dietl, G., Mosbrugger, V., Scheidegger, C., Frank, D., Damuth, J., Stenseth, N.-C., Fortelius, M. 2011. History Matters: Integrative Climate Change Biology. <i>Proceedings of the Royal Society B</i> 278: 1131-1140. <a href="{% static "now/pdf/Polly_etal_2011.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <h4>2010</h4>
 
-  <hr>Eronen, J. T., Polly, P.D., Fred, M., Damuth, J., Frank, D. C., Mosbrugger, V., Scheidegger, C., Stenseth, N. C., Fortelius, M. 2010. Ecometrics: The traits that bind the past and present together.<i>Integrative Zoology</i> 5: 88-101. <a href="{% static "now/pdf/Eronen_etal_IZ_2010.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Eronen, J. T., Polly, P.D., Fred, M., Damuth, J., Frank, D. C., Mosbrugger, V., Scheidegger, C., Stenseth, N. C., Fortelius, M. 2010. Ecometrics: The traits that bind the past and present together.<i>Integrative Zoology</i> 5: 88-101. <a href="{% static "now/pdf/Eronen_etal_IZ_2010.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
-  <hr>Eronen, J. T., Puolamäki, K., Liu, L., Lintulaakso, K., Damuth, J., Janis, C., Fortelius, M. 2010. Precipitation and large herbivorous mammals , part II: Application to fossil data. <i>Evolutionary Ecology Research</i> 12: 235-248. <a href="{% static "now/pdf/hhar2539.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Eronen, J. T., Puolamäki, K., Liu, L., Lintulaakso, K., Damuth, J., Janis, C., Fortelius, M. 2010. Precipitation and large herbivorous mammals , part II: Application to fossil data. <i>Evolutionary Ecology Research</i> 12: 235-248. <a href="{% static "now/pdf/hhar2539.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
-  <hr>Eronen, J. T., Puolamäki, K., Liu, L., Lintulaakso, K., Damuth, J., Janis, C., Fortelius, M. 2010. Precipitation and large herbivorous mammals , part I: Estimates from present-day communities. <i>Evolutionary Ecology Research</i> 12: 217-233. <a href="{% static "now/pdf/ggar2538.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Eronen, J. T., Puolamäki, K., Liu, L., Lintulaakso, K., Damuth, J., Janis, C., Fortelius, M. 2010. Precipitation and large herbivorous mammals , part I: Estimates from present-day communities. <i>Evolutionary Ecology Research</i> 12: 217-233. <a href="{% static "now/pdf/ggar2538.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
-  <hr>Eronen, J. T. , Evans, A.R., Jernvall, J., Fortelius, M. 2010. The impact of regional climate on the evolution of mammals. A case study using fossil horses. <i>Evolution</i> 64: 398-408. <a href="{% static "now/pdf/Eronen_etal_2010.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Eronen, J. T. , Evans, A.R., Jernvall, J., Fortelius, M. 2010. The impact of regional climate on the evolution of mammals. A case study using fossil horses. <i>Evolution</i> 64: 398-408. <a href="{% static "now/pdf/Eronen_etal_2010.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
-  <hr>Saarinen, J., Oikarinen, E., Fortelius, M. and Mannila H. 2010. The living and the fossilised – how well do unevenly distributed points capture the faunal information in a grid? <i>Evolutionary Ecology Research</i> 12: 363-376.<a href="{% static "now/pdf/Saarinen_etal_2010.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Saarinen, J., Oikarinen, E., Fortelius, M. and Mannila H. 2010. The living and the fossilised – how well do unevenly distributed points capture the faunal information in a grid? <i>Evolutionary Ecology Research</i> 12: 363-376.<a href="{% static "now/pdf/Saarinen_etal_2010.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Solounias, N., Rivals, F., and Semprebon, G.M. 2010. Dietary interpretation and paleoecology of herbivores from Pikermi and Samos (late Miocene of Greece). <i>Paleobiology</i> 3: 113-136.
 
@@ -306,31 +306,31 @@
   <hr>Bernor, R.L., Rook L., and Haile-Selassie Y. 2009. Paleobiogeography. <b>In:</b> (eds.) Haile-Selassie Y. and Wolde Gabriel G. <i>Ardipithecus kadabba: Late Miocene Evidence from the Middle Awash, Ethiopia</i>. University of California Press, Los Angeles, pp. 549-563.
 
   <hr>Eronen J. T., Mirzaie Ataabadi M., Micheels A., Karme A., Bernor R. L., and Fortelius M. 2009. Distribution history and climatic controls of the Late Miocene Pikermian chronofauna. <i>PNAS</i> 106(29): 11867-11871.
-      <a href="{% static "now/pdf/eronen_etal_PNAS_2009.pdf" %}" target="_blank">[PDF]</a>
+      <a href="{% static "now/pdf/eronen_etal_PNAS_2009.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Koufos, G.D., Kostopoulos, D.S., and Merceron G. 2009. Palaeoecology and Palaeobiogeography. <b>In:</b> (eds.) Koufos G.D. and Nagel D. <i>The Late Miocene Mammal Faunas of the Mytilinii Basin, Samos Island, Greece: New Collection</i>. Beiträge zur Paläontologie 31: 409-428.
 
-  <hr>Liu L., Eronen J. T., and Fortelius M. 2009. Significant Mid-Latitude Aridity in the Middle Miocene of East Asia. <i>Palaeoclimatology, Palaeogeography, Palaeoecology</i> 279: 201-206. <a href="{% static "now/pdf/Liu_etal_2009.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Liu L., Eronen J. T., and Fortelius M. 2009. Significant Mid-Latitude Aridity in the Middle Miocene of East Asia. <i>Palaeoclimatology, Palaeogeography, Palaeoecology</i> 279: 201-206. <a href="{% static "now/pdf/Liu_etal_2009.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
-  <hr>Micheels, A., Eronen, J.T., and Mosbrugger, V. 2009. The Late Miocene climate sensitivity on a modern Sahara desert. <i>Global and Planetary Change</i> 67: 193-204. <a href="{% static "now/pdf/Micheels_etal_2009.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Micheels, A., Eronen, J.T., and Mosbrugger, V. 2009. The Late Miocene climate sensitivity on a modern Sahara desert. <i>Global and Planetary Change</i> 67: 193-204. <a href="{% static "now/pdf/Micheels_etal_2009.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Nargolwalla, M.C. 2009. Eurasian Middle and Late Miocene Hominoid Paleobiogeography and the Geographic Origins of the Homininae. Ph.D. dissertation, University of Toronto.
 
   <hr>Peláez-Campomanes, P. and van der Meulen, A.J., 2009. Diversity of mammals in the Neogene of Europe: comparing data quality of large and small mammals in the NOW database.
     <i>Hellen. J. Geosci</i>, 44, pp.105-115.
-    <a href="{% static "now/pdf/GEOL 44 105-116.pdf" %}" target="_blank">[PDF]</a>
+    <a href="{% static "now/pdf/GEOL 44 105-116.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <h4>2008</h4>
 
-  <hr>Liow, L.H., Fortelius M., Bingham E., Lintulaakso K., Mannila H., Flynn L. and Stenseth N. C. 2008. Higher originaltion and extinction ratesin larger mammals. <i>PNAS</i> 105 (16): 6097-6102. <a href="{% static "now/pdf/Liow_etal_SLOH_PNAS_08.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Liow, L.H., Fortelius M., Bingham E., Lintulaakso K., Mannila H., Flynn L. and Stenseth N. C. 2008. Higher originaltion and extinction ratesin larger mammals. <i>PNAS</i> 105 (16): 6097-6102. <a href="{% static "now/pdf/Liow_etal_SLOH_PNAS_08.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
-  <hr>Liow L.H., Fortelius M., Bingham E., Lintulaakso K. , Mannila H., Flynn L. and Stenseth N. C. 2008. Sleep or hide, better for survival anytime (reply to Casanovas-Vilar et al.). <i>PNAS</i> 105 (35): E57. <a href="{% static "now/pdf/PNAS-2008-Liow-E57.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Liow L.H., Fortelius M., Bingham E., Lintulaakso K. , Mannila H., Flynn L. and Stenseth N. C. 2008. Sleep or hide, better for survival anytime (reply to Casanovas-Vilar et al.). <i>PNAS</i> 105 (35): E57. <a href="{% static "now/pdf/PNAS-2008-Liow-E57.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Bernor, R.L. and L. Rook. 2008. A Current View of As-Sahabi Large Mammal Biogeographic Relationships, <i>Garyounis Scientific Bulletin</i>, Special Issue 5: 285-292.
 
   <h4>2007</h4>
 
-  <hr>Bingham E., Kabán A., and Fortelius M. 2007. The aspect Bernoulli model: multiple causes of presences and absences. <span style="font-style: italic;">Pattern Analysis &amp; Applications</span> 12: 55-78 DOI:10.1007/s10044-007-0096-4. <a href="{% static "now/pdf/Bingham_et_al_2007_PAA.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Bingham E., Kabán A., and Fortelius M. 2007. The aspect Bernoulli model: multiple causes of presences and absences. <span style="font-style: italic;">Pattern Analysis &amp; Applications</span> 12: 55-78 DOI:10.1007/s10044-007-0096-4. <a href="{% static "now/pdf/Bingham_et_al_2007_PAA.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Hopkins SSB. 2007. Causes of lineage decline in the Aplodontidae:&nbsp; Testing for the influence of physical and biological change.&nbsp; <span style="font-style: italic;">Palaeogeography, Palaeoclimatology, Palaeoecology</span> 246: 331-335.
 
@@ -339,34 +339,34 @@
   <hr>Eronen J. T. 2006. Eurasian Neogene large herbivorous mammals and climate. <span style="font-style: italic;">Acta Zoologica Fennica</span> 216: 1-72.
 
   <hr>Fortelius M, Eronen J. T., Liu L, Pushkina D, Tesakov A, Vislobokova IA, and Zhang Z. 2006. Late Miocene and Pliocene large land mammals and climatic changes in Eurasia. <span style="font-style: italic;">Palaeogeography, Palaeoclimatology,
-  Palaeoecology</span> 238: 219-227. <a href="{% static "now/pdf/Fortelius_et_al_2006_PPP.pdf" %}" target="_blank">[PDF]</a>
+  Palaeoecology</span> 238: 219-227. <a href="{% static "now/pdf/Fortelius_et_al_2006_PPP.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
-  <hr>Fortelius M, Gionis A, Jernvall J, and Mannila H. 2006. Spectral ordering and biochronology of European fossil mammals. <span style="font-style: italic;">Paleobiology</span> 32(2): 206-214. <a href="{% static "now/pdf/Fortelius_et_al_2006_PB.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Fortelius M, Gionis A, Jernvall J, and Mannila H. 2006. Spectral ordering and biochronology of European fossil mammals. <span style="font-style: italic;">Paleobiology</span> 32(2): 206-214. <a href="{% static "now/pdf/Fortelius_et_al_2006_PB.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Fortelius M, and Zhang Z. 2006. An Oasis in the Desert? History of Endemism and Climate in the Late Neogene of North China. <span style="font-style: italic;">Palaeontographica A</span>. 277: 131-141.
-      <a href="{% static "now/pdf/Fortelius_Zhang_2006_PalaeoA.pdf" %}" target="_blank">[PDF]</a>
+      <a href="{% static "now/pdf/Fortelius_Zhang_2006_PalaeoA.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
-  <hr>Puolamäki K, Fortelius M, and Mannila H. 2006. Seriation in paleontological data using Markov Chain Monte Carlo methods. <span style="font-style: italic;">PLoS Computational Biology</span> 2(2): e6. <a href="{% static "now/pdf/Puolamaki_et_al_2006_PLoS.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Puolamäki K, Fortelius M, and Mannila H. 2006. Seriation in paleontological data using Markov Chain Monte Carlo methods. <span style="font-style: italic;">PLoS Computational Biology</span> 2(2): e6. <a href="{% static "now/pdf/Puolamaki_et_al_2006_PLoS.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Koufos GD. 2006. Palaeoecology and chronology of the Vallesian (late Miocene) in the Eastern Mediterranean region. <span style="font-style: italic;">Palaeoclimatology, Palaeogeography, Palaeoecology</span>. 234: 127-145.
 
   <h4>2005</h4>
 
-  <hr>Ukkonen A, Fortelius M, and Mannila H. 2005. Finding partial orders from unordered 0–1 data. <span style="font-weight: bold;">In:</span> Grossman R, Bayardo R and Bennett KP. (eds.) <span style="font-style: italic;">Proceedings of the Eleventh ACM SIGKDD International Conference on Knowledge Discovery and Data Mining, Chicago, Illinois, USA, August 21–24, 2005</span>. pp. 285-293. <a href="{% static "now/pdf/Ukkonen_et_al_2005_KDD05.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Ukkonen A, Fortelius M, and Mannila H. 2005. Finding partial orders from unordered 0–1 data. <span style="font-weight: bold;">In:</span> Grossman R, Bayardo R and Bennett KP. (eds.) <span style="font-style: italic;">Proceedings of the Eleventh ACM SIGKDD International Conference on Knowledge Discovery and Data Mining, Chicago, Illinois, USA, August 21–24, 2005</span>. pp. 285-293. <a href="{% static "now/pdf/Ukkonen_et_al_2005_KDD05.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <h4>2004</h4>
 
-  <hr>Eronen J. T., and Rook L. 2004. The Mio-Pliocene European primate fossil record: dynamics and habitat tracking. <span style="font-style: italic;">Journal of Human Evolution</span> 47(5): 323-341. <a href="{% static "now/pdf/Eronen_Rook_2004_JHE.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Eronen J. T., and Rook L. 2004. The Mio-Pliocene European primate fossil record: dynamics and habitat tracking. <span style="font-style: italic;">Journal of Human Evolution</span> 47(5): 323-341. <a href="{% static "now/pdf/Eronen_Rook_2004_JHE.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Jernvall J, and Fortelius M. 2004. Maintenance of trophic structure in fossil mammal communities: site occupancy and taxon resilience. <span style="font-style: italic;">American Naturalist</span> 164(5): 614-624.
-      <a href="{% static "now/pdf/Jernvall_Fortelius_2004_AmNat.pdf" %}" target="_blank">[PDF]</a>
+      <a href="{% static "now/pdf/Jernvall_Fortelius_2004_AmNat.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <h4>2003</h4>
 
   <hr>Fortelius M. 2003. Evolution of dental capability in Western Eurasian large mammal plant-eaters 22–2 million years ago: a case for environmental forcing mediated by biotic processes. <span style="font-weight: bold;">In:</span> Legakis A, Sfenthourakis S, Polymeni R and Thessalou-Legaki M. (eds.) <span style="font-style: italic;">The New Panorama of Animal Evolution: Proceedings of the XVIII International Congress of Zoology, Athens, Greece, September 2000</span>. Pensoft, Sofia-Moscow.
-      <a href="{% static "now/datasets/Fortelius_2003_ICZ2000.zip" %}" target="_blank">[dataset]</a>
+      <a href="{% static "now/datasets/Fortelius_2003_ICZ2000.zip" %}" target="_blank" rel="noopener">[dataset]</a>
 
-  <hr>Fortelius M, Eronen J, Liu LP, Pushkina D, Tesakov A, Vislobokova I, and Zhang ZQ. 2003. Continental-scale hypsodonty patterns, climatic paleobiogeography and dispersal of Eurasian Neogene large mammal herbivores. <span style="font-weight: bold;">In:</span> Reumer JWF, and Wessels W. (eds.) Distribution and Migration of Tertiary Mammals in Eurasia. A volume in honour of Hans de Bruijn. <span style="font-style: italic;">Deinsea</span> 10: 1-11. <a href="{% static "now/pdf/Fortelius_et_al_2003_Deinsea.pdf" %}" target="_blank">[PDF]</a> <a href="{% static "now/datasets/Fortelius_et_al_2003_Deinsea.zip" %}" target="_blank">[dataset]</a>
+  <hr>Fortelius M, Eronen J, Liu LP, Pushkina D, Tesakov A, Vislobokova I, and Zhang ZQ. 2003. Continental-scale hypsodonty patterns, climatic paleobiogeography and dispersal of Eurasian Neogene large mammal herbivores. <span style="font-weight: bold;">In:</span> Reumer JWF, and Wessels W. (eds.) Distribution and Migration of Tertiary Mammals in Eurasia. A volume in honour of Hans de Bruijn. <span style="font-style: italic;">Deinsea</span> 10: 1-11. <a href="{% static "now/pdf/Fortelius_et_al_2003_Deinsea.pdf" %}" target="_blank" rel="noopener">[PDF]</a> <a href="{% static "now/datasets/Fortelius_et_al_2003_Deinsea.zip" %}" target="_blank" rel="noopener">[dataset]</a>
 
   <p>•Bernor RL, Kordos L, and Rook L. 2003. Recent Advances on Multidisciplinary Research at Rudab‡nya, Late Miocene (MN9), Hungary: A compendium. <span style="font-style: italic;">Palaeontographia Italica</span> 89: 3-36.
 
@@ -374,9 +374,9 @@
 
   <h4>2002</h4>
 
-  <hr>Fortelius M, Eronen J, Jernvall J, Liu L, Pushkina D, Rinne J, Tesakov A, Vislobokova I, Zhang Z, and Zhou L. 2002. Fossil mammals resolve regional patterns of Eurasian climate change over 20 million years. <span style="font-style: italic;">Evolutionary Ecology Research</span> 4: 1005-1016. <a href="{% static "now/pdf/Fortelius_et_al_2002_EER.pdf" %}" target="_blank">[PDF]</a> <a href="{% static "now/datasets/Fortelius_et_al_2002_EER.zip" %}" target="_blank">[dataset]</a>
+  <hr>Fortelius M, Eronen J, Jernvall J, Liu L, Pushkina D, Rinne J, Tesakov A, Vislobokova I, Zhang Z, and Zhou L. 2002. Fossil mammals resolve regional patterns of Eurasian climate change over 20 million years. <span style="font-style: italic;">Evolutionary Ecology Research</span> 4: 1005-1016. <a href="{% static "now/pdf/Fortelius_et_al_2002_EER.pdf" %}" target="_blank" rel="noopener">[PDF]</a> <a href="{% static "now/datasets/Fortelius_et_al_2002_EER.zip" %}" target="_blank" rel="noopener">[dataset]</a>
 
-  <hr>Jernvall, J, and Fortelius M. 2002. Common mammals drive the evolutionary increase of hypsodonty in the Neogene. <span style="font-style: italic;">Nature</span> 417: 538-540. <a href="{% static "now/pdf/Jernvall_Fortelius_2002_Nature.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Jernvall, J, and Fortelius M. 2002. Common mammals drive the evolutionary increase of hypsodonty in the Neogene. <span style="font-style: italic;">Nature</span> 417: 538-540. <a href="{% static "now/pdf/Jernvall_Fortelius_2002_Nature.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <h4>2001</h4>
 
@@ -384,17 +384,17 @@
 
   <hr>Agustí J, Cabrera L, and Garcés, M. 2001. Chronology and zoogeography of the Miocene hominoid record in Europe. <span style="font-weight: bold;">In:</span> de Bonis L, Koufos GD, and Andrews P. (eds.) <span style="font-style: italic;">Hominoid Evolution and Climate Change: Volume 2, Phylogeny of the Neogene Hominoid Primates of Eurasia</span>. pp. 2-18. Cambridge University Press, London.
 
-  <hr>Agustí J, Cabrera L, Garcés, M, Krijgsman W, Oms O, and Parés JM. 2001. A calibrated mammal scale for the Neogene of Western Europe. State of the art. <span style="font-style: italic;">Earth Science Reviews</span> 52: 247–260. <a href="{% static "now/pdf/Agusti_et_al_2001_ESR.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Agustí J, Cabrera L, Garcés, M, Krijgsman W, Oms O, and Parés JM. 2001. A calibrated mammal scale for the Neogene of Western Europe. State of the art. <span style="font-style: italic;">Earth Science Reviews</span> 52: 247–260. <a href="{% static "now/pdf/Agusti_et_al_2001_ESR.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Agustí J, and Oms O. 2001. On the age of the last hipparionine faunas in western Europe. <span style="font-style: italic;">Comptes Rendus de l'Academie des Sciences Series IIA Earth and Planetary Science</span> 332(4): 291-297.
 
   <hr>Agustí J, Oms O, and Remacha E. 2001. Long Plio-Pleistocene Terrestrial Record of Climate Change and Mammal Turnover in Southern Spain. <span style="font-style: italic;">Quaternary Research</span> 56(3): 411-418.
 
-  <hr>Alba DM, Agustí J, and Moyà-Solà S. 2001. Completeness of the mammalian fossil record in the Iberian Neogene. <span style="font-style: italic;">Paleobiology</span> 27(1): 79-83. <a href="{% static "now/pdf/Alba_et_al_2001_PB.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Alba DM, Agustí J, and Moyà-Solà S. 2001. Completeness of the mammalian fossil record in the Iberian Neogene. <span style="font-style: italic;">Paleobiology</span> 27(1): 79-83. <a href="{% static "now/pdf/Alba_et_al_2001_PB.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
   <hr>Bernor RL, Fortelius M, and Rook L. 2001. Evolutionary Biogeography and Paleoecology of the <span style="font-style: italic;">Oreopithecus bambolii</span> ”Faunal Zone” (late Miocene, Tusco-Sardinian Province). <span style="font-weight: bold;">In:</span> Rook L, and Torre D. (eds.) Neogene and Quaternary continental stratigraphy and mammal evolution. <span style="font-style: italic;">Bollettino della Società Paleontologica Italiana</span> 40(2): 139-148.
-      <a href="{% static "now/datasets/Bernor_et_al_2001_BSPI.zip" %}" target="_blank">[dataset]</a>
-  <hr>Fortelius M, and Hokkanen A. 2001. The trophic context of hominoid occurrence in the Later Miocene of Western Eurasia – a primate-free view. <span style="font-weight: bold;">In:</span> de Bonis L, Koufos GD, and Andrews P. (eds.) <span style="font-style: italic;">Hominoid Evolution and Climate Change: Volume 2, Phylogeny of the Neogene Hominoid Primates of Eurasia</span>. pp. 19-47. Cambridge University Press, London. <a href="{% static "now/datasets/Fortelius_Hokkanen_2001_HECC.zip" %}" target="_blank">[dataset]</a>
+      <a href="{% static "now/datasets/Bernor_et_al_2001_BSPI.zip" %}" target="_blank" rel="noopener">[dataset]</a>
+  <hr>Fortelius M, and Hokkanen A. 2001. The trophic context of hominoid occurrence in the Later Miocene of Western Eurasia – a primate-free view. <span style="font-weight: bold;">In:</span> de Bonis L, Koufos GD, and Andrews P. (eds.) <span style="font-style: italic;">Hominoid Evolution and Climate Change: Volume 2, Phylogeny of the Neogene Hominoid Primates of Eurasia</span>. pp. 19-47. Cambridge University Press, London. <a href="{% static "now/datasets/Fortelius_Hokkanen_2001_HECC.zip" %}" target="_blank" rel="noopener">[dataset]</a>
 
   <hr>Garcés M, Krijgsman W, and Agustí J. 2001. Chronostratigraphic framework and evolution of the Fortuna basin (Eastern Betics) since the Late Miocene. <span style="font-style: italic;">Basin Research</span> 13(2): 199-216.
 
@@ -404,9 +404,9 @@
 
   <h4>1998</h4>
 
-  <hr>Agusti J, Andrews P, Fortelius M, and Rook L. 1998. Hominoid evolution and environmental change in the Neogene of Europe: a European Science Foundation network. <span style="font-style: italic;">Journal of Human Evolution</span> 34(1): 103-107. <a href="{% static "now/pdf/Agusti_et_al_1998_JHE.pdf" %}" target="_blank">[PDF]</a>
+  <hr>Agusti J, Andrews P, Fortelius M, and Rook L. 1998. Hominoid evolution and environmental change in the Neogene of Europe: a European Science Foundation network. <span style="font-style: italic;">Journal of Human Evolution</span> 34(1): 103-107. <a href="{% static "now/pdf/Agusti_et_al_1998_JHE.pdf" %}" target="_blank" rel="noopener">[PDF]</a>
 
-  <hr>Alroy J, Bernor RL, Fortelius M, and Werdelin L. 1998. The MN system: regional or continental? <span style="font-style: italic;">Mitteilungen der Bayerischen Staatssamlung für Paläontologie und historische Geologie</span> 38: 243-258. <a href="{% static "now/datasets/Alroy_et_al_1998_MBS.zip" %}" target="_blank">[dataset]</a>
+  <hr>Alroy J, Bernor RL, Fortelius M, and Werdelin L. 1998. The MN system: regional or continental? <span style="font-style: italic;">Mitteilungen der Bayerischen Staatssamlung für Paläontologie und historische Geologie</span> 38: 243-258. <a href="{% static "now/datasets/Alroy_et_al_1998_MBS.zip" %}" target="_blank" rel="noopener">[dataset]</a>
   <h4>1997</h4>
 
   <hr>Werdelin L, and Fortelius M. 1997. Biogeographic characterisation of MN unit reference localities. <span style="font-weight: bold;">In:</span> Aguilar J-P, Legendre S, and Michaux J. (eds.) Actes du Congrès BiochroM'97. <span style="font-style: italic;">Mémoires et Travaux, École Pratique des Hautes Études, Institut de Montpellier</span> 21: 67-73.
@@ -417,9 +417,9 @@
 
   <hr>Fortelius M, Andrews P, Bernor RL, and Werdelin L. 1996. Preliminary analysis of taxonomic diversity, turnover and provinciality in a subsample of large land mammals from the later Miocene of western Eurasia. <span style="font-weight: bold;">In:</span> Nadachowski A, and Werdelin L. (eds.) Neogene and Quaternary Mammals of the Palaearctic. Conference in honour of Professor Kazimierz Kowalski. <span style="font-style: italic;">Acta Zoologica Cracoviensia</span> 39: 167-178.
 
-  <hr>Fortelius M, van der Made J, and Bernor R. 1996. Middle and Late Miocene Suoidea of central Europe and the eastern Mediterranean: evolution, biogeography and paleoecology. <span style="font-weight: bold;">In:</span> Bernor RL,Fahlbusch V, and Mittmann W. (eds.) <span style="font-style: italic;">The Evolution of Western Eurasian Neogene Mammal Faunas</span>. pp. 348-377. Columbia University Press. <a href="{% static "now/datasets/Fortelius_et_al_1996_EWENMF.zip" %}" target="_blank">[dataset]</a>
+  <hr>Fortelius M, van der Made J, and Bernor R. 1996. Middle and Late Miocene Suoidea of central Europe and the eastern Mediterranean: evolution, biogeography and paleoecology. <span style="font-weight: bold;">In:</span> Bernor RL,Fahlbusch V, and Mittmann W. (eds.) <span style="font-style: italic;">The Evolution of Western Eurasian Neogene Mammal Faunas</span>. pp. 348-377. Columbia University Press. <a href="{% static "now/datasets/Fortelius_et_al_1996_EWENMF.zip" %}" target="_blank" rel="noopener">[dataset]</a>
 
-  <hr>Fortelius M, Werdelin L. Andrews P, Bernor RL, Gentry A, Humphrey L, Mittmann W, and Viranta S. 1996. Provinciality, diversity, turnover and paleoecology in land mammal faunas of the later Miocene of western Eurasia. <span style="font-weight: bold;">In:</span> Bernor RL, Fahlbusch V, and Mittmann W. (eds.) <span style="font-style: italic;">The Evolution of Western Eurasian Neogene Mammal Faunas</span>. pp. 414-448. Columbia University Press. <a href="{% static "now/datasets/Fortelius_et_al_1996_EWENMF.zip" %}" target="_blank">[dataset]</a>
+  <hr>Fortelius M, Werdelin L. Andrews P, Bernor RL, Gentry A, Humphrey L, Mittmann W, and Viranta S. 1996. Provinciality, diversity, turnover and paleoecology in land mammal faunas of the later Miocene of western Eurasia. <span style="font-weight: bold;">In:</span> Bernor RL, Fahlbusch V, and Mittmann W. (eds.) <span style="font-style: italic;">The Evolution of Western Eurasian Neogene Mammal Faunas</span>. pp. 414-448. Columbia University Press. <a href="{% static "now/datasets/Fortelius_et_al_1996_EWENMF.zip" %}" target="_blank" rel="noopener">[dataset]</a>
 
 </section>
 {% endblock %}

--- a/now/templates/publications.html
+++ b/now/templates/publications.html
@@ -28,6 +28,9 @@
   <hr>Gaiser, F., Müller, C., Phan, P., Mathes, G. and Steinbauer, M.J., 2025. Europe’s lost landscape sculptors: Today’s potential range of the extinct elephant Palaeoloxodon antiquus.
     In <i>Frontiers of Biogeography</i>, 18, p.e135081.
     <a href="https://doi.org/10.21425/fob.18.135081" target="_blank" rel="noopener">[DOI]</a>
+  <hr>Blanco, F., Lazagabaster, I.A., Sanisidro, Ó., Bibi, F., Heckeberg, N.S., Ríos, M., Mennecart, B., Alberdi, M.T., Prado, J.L., Saarinen, J. and Silvestro, D., 2025. Two major ecological shifts shaped 60 million years of ungulate faunal evolution.
+    In <i>Nature Communications</i>, 16(1), p.4648.
+    <a href="https://doi.org/10.1038/s41467-025-04648-8" target="_blank" rel="noopener">[DOI]</a>
     <h4>2024</h4>
     <hr>Bekeraitė, S., Juchnevičiūtė, I. and Spiridonov, A., 2024. Bayesian network analysis reveals the assembly drivers and emergent stability of Eurasian Pleistocene large mammal communities.
     In <i>Journal of Mammalian Evolution</i>, 31(4), pp.1-16.

--- a/now/templates/publications.html
+++ b/now/templates/publications.html
@@ -30,7 +30,7 @@
     <a href="https://doi.org/10.21425/fob.18.135081" target="_blank" rel="noopener">[DOI]</a>
   <hr>Blanco, F., Lazagabaster, I.A., Sanisidro, Ó., Bibi, F., Heckeberg, N.S., Ríos, M., Mennecart, B., Alberdi, M.T., Prado, J.L., Saarinen, J. and Silvestro, D., 2025. Two major ecological shifts shaped 60 million years of ungulate faunal evolution.
     In <i>Nature Communications</i>, 16(1), p.4648.
-    <a href="https://doi.org/10.1038/s41467-025-04648-8" target="_blank" rel="noopener">[DOI]</a>
+    <a href="https://doi.org/10.1038/s41467-025-59974-x" target="_blank" rel="noopener">[DOI]</a>
     <h4>2024</h4>
     <hr>Bekeraitė, S., Juchnevičiūtė, I. and Spiridonov, A., 2024. Bayesian network analysis reveals the assembly drivers and emergent stability of Eurasian Pleistocene large mammal communities.
     In <i>Journal of Mammalian Evolution</i>, 31(4), pp.1-16.


### PR DESCRIPTION
## Summary
- mitigate potential reverse tabnabbing by adding `rel="noopener"` to external links in publications page

## Testing
- `python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*
- `pip install django` *(fails: Could not find a version that satisfies the requirement django)*

------
https://chatgpt.com/codex/tasks/task_e_689075eba7e083299593e4e2b6eb6827