### PR TITLE
Fix dataset static path

### DIFF
--- a/now/models.py
+++ b/now/models.py
@@ -49,4 +49,4 @@ class Publication(models.Model):
             return ""
         if self.dataset.startswith(("http://", "https://")):
             return self.dataset
-        return static(f"now/dataset/{self.dataset}")
+        return static(f"now/datasets/{self.dataset}")

--- a/now/tests.py
+++ b/now/tests.py
@@ -26,7 +26,7 @@ class PublicationViewTests(TestCase):
         self.assertContains(response, '[PDF]')
         self.assertContains(response, '/static/now/pdf/example.pdf')
         self.assertContains(response, '[dataset]')
-        self.assertContains(response, '/static/now/dataset/data.csv')
+        self.assertContains(response, '/static/now/datasets/data.csv')
         self.assertContains(response, '[doi:10.1234/example]')
         self.assertContains(response, 'https://doi.org/10.1234/example')
 


### PR DESCRIPTION
## Summary
- fix dataset link path to reference `now/datasets` directory
- update tests expecting dataset link

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_6891f2b7cfdc832980c2307112e63e7e